### PR TITLE
Set the date to a fixed value when retrieving data from Covid19JapanAll api

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,15 +33,20 @@ const TopRoot: FunctionComponent<Props> = (props) => {
 
 export const getServerSideProps: GetServerSideProps = async () => {
     const github = await getGithub();
-    let coronaByDate = null;
-    let coronaByDateOneDayAge = null;
-    for (let i = 0; i < 10; ++i) {
-        coronaByDate = await getCoronaByDate(getBeforeNdays(i));
-        if (coronaByDate?.itemList && coronaByDate.itemList.length !== 0) {
-            coronaByDateOneDayAge = await getCoronaByDate(getBeforeNdays(i + 1));
-            break;
-        }
-    }
+    // MEMO: 20230509以降情報更新がされないため、固定で日付を設定してデータを取得する
+    // let coronaByDate = null;
+    // let coronaByDateOneDayAge = null;
+    // for (let i = 0; i < 10; ++i) {
+    //     coronaByDate = await getCoronaByDate(getBeforeNdays(i));
+    //     console.log('coronaByDate');
+    //     console.log(coronaByDate);
+    //     if (coronaByDate?.itemList && coronaByDate.itemList.length !== 0) {
+    //         coronaByDateOneDayAge = await getCoronaByDate(getBeforeNdays(i + 1));
+    //         break;
+    //     }
+    // }
+    const coronaByDate = await getCoronaByDate('20230509');
+    const coronaByDateOneDayAge = await getCoronaByDate('20230508');
     if (!coronaByDate || !coronaByDateOneDayAge) {
         return {
             props: {


### PR DESCRIPTION
## 概要(overview)
全国のコロナ感染者数(都道府県別)の日付検索条件を固定値にする

## チケット(ticket)

ticket | url
-- | --
全国のコロナ感染者数(都道府県別)のデータが取得できない | https://github.com/will-of-work-80/corona-info/issues/15

## 詳細(detail)
- 既存処理はコメント
- 検索条件の日付を固定値にする(`20230509`, `20230508`)

## テスト(test)

<img src="https://github.com/will-of-work-80/corona-info/assets/123068048/06a21b37-863e-4232-ad71-6fd84c28b378" width="500px" />
