### PR TITLE
Add occurrence-status-country api

### DIFF
--- a/src/server/occurrence-status-country/data.ts
+++ b/src/server/occurrence-status-country/data.ts
@@ -1,0 +1,60 @@
+import fetch from 'node-fetch';
+import { OccurrenceStatusCountryInfoEntity, OccurrenceStatusCountryItemEntity } from './entity';
+import { OccurrenceStatusCountryInfoRaw } from './raw';
+import { CLIENT_ERROR_MESSAGE } from '../../utils/check-error';
+
+const OCCURRENCE_STATUS_COUNTRY_INFO_URL = 'https://opendata.corona.go.jp/api/OccurrenceStatusOverseas';
+
+export type OccurrenceStatusCountryInfoProps = OccurrenceStatusCountryInfoEntity;
+
+const useFetch = async (url: string): Promise<OccurrenceStatusCountryInfoRaw> => {
+    try {
+        const res = await fetch(url, {
+            method: 'GET',
+        });
+        if (!res.ok) {
+            console.error('Connection Failed!');
+            if (res.status === 404) {
+                return {
+                    errorInfo: CLIENT_ERROR_MESSAGE.NOT_FOUND_ERROR,
+                    itemList: null,
+                };
+            }
+            return {
+                errorInfo: {
+                    ...CLIENT_ERROR_MESSAGE.NOT_FOUND_ERROR,
+                    errorMessage: res.statusText,
+                },
+                itemList: null,
+            };
+        }
+        return res.json();
+    } catch (e) {
+        return {
+            errorInfo: CLIENT_ERROR_MESSAGE.NOT_FOUND_ERROR,
+            itemList: null,
+        };
+    }
+};
+
+const converter = async (data: Promise<OccurrenceStatusCountryInfoRaw | null>): Promise<OccurrenceStatusCountryInfoEntity | null> => {
+    const info = await data;
+    if (info === null) {
+        return null;
+    }
+
+    const itemList = info.itemList?.map((arg) => OccurrenceStatusCountryItemEntity.converter(arg)) || null;
+    return {
+        errorInfo: info.errorInfo,
+        itemList,
+    };
+};
+
+const getOccurrenceStatusCountryInfo = (country: string): Promise<OccurrenceStatusCountryInfoProps | null> => {
+    const occurrenceStatusCountry = useFetch(`${OCCURRENCE_STATUS_COUNTRY_INFO_URL}?dataName=${country}`);
+    return converter(occurrenceStatusCountry);
+};
+
+export const getOccurrenceStatusCountryInfoOfJapan = (): Promise<OccurrenceStatusCountryInfoProps | null> => {
+    return getOccurrenceStatusCountryInfo('日本');
+};

--- a/src/server/occurrence-status-country/entity.ts
+++ b/src/server/occurrence-status-country/entity.ts
@@ -1,0 +1,38 @@
+import { OccurrenceStatusCountryItemRaw } from './raw';
+
+export interface OccurrenceStatusCountryInfoEntity {
+    errorInfo: {
+        errorFlag: string;
+        errorCode: string | null;
+        errorMessage: string | null;
+    };
+    itemList: Array<OccurrenceStatusCountryItemEntity> | null;
+}
+
+// export interface OccurrenceStatusCountryViewEntity {
+// }
+
+interface Input {
+    date: string;
+    dataName: string;
+    infectedNum: string;
+    deceasedNum: string;
+}
+
+export class OccurrenceStatusCountryItemEntity {
+    readonly date: string;
+    readonly country: string;
+    readonly infectedNum: string;
+    readonly deceasedNum: string;
+
+    constructor(info: Input) {
+        this.date = info.date;
+        this.country = info.dataName;
+        this.infectedNum = info.infectedNum;
+        this.deceasedNum = info.deceasedNum;
+    }
+
+    static converter(raw: OccurrenceStatusCountryItemRaw) {
+        return new OccurrenceStatusCountryItemEntity(raw);
+    }
+}

--- a/src/server/occurrence-status-country/raw.ts
+++ b/src/server/occurrence-status-country/raw.ts
@@ -1,0 +1,15 @@
+export interface OccurrenceStatusCountryItemRaw {
+    date: string;
+    dataName: string;
+    infectedNum: string;
+    deceasedNum: string;
+}
+
+export interface OccurrenceStatusCountryInfoRaw {
+    errorInfo: {
+        errorFlag: string;
+        errorCode: string | null;
+        errorMessage: string | null;
+    };
+    itemList: ReadonlyArray<OccurrenceStatusCountryItemRaw> | null;
+}


### PR DESCRIPTION
## 概要(overview)
各国別感染者数・死亡者数 オープンデータAPI実装

## チケット(ticket)

ticket | url
-- | --
各国別感染者数・死亡者数 オープンデータAPI実装 | https://github.com/will-of-work-80/corona-info/issues/1

## 詳細(detail)
各国別感染者数・死亡者数をJSON形式で貰えるAPI。

- 取得URL : 
  - https://opendata.corona.go.jp/api/OccurrenceStatusOverseas?dataName=%E6%97%A5%E6%9C%AC

詳細はissueを参考

## テスト(test)
