### PR TITLE
Add navigation component

### DIFF
--- a/public/navigation-button.svg
+++ b/public/navigation-button.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <line y1="2.80005" x2="24" y2="2.80005" stroke="black" stroke-width="2"/>
+    <line y1="11.8" x2="24" y2="11.8" stroke="black" stroke-width="2"/>
+    <line y1="20.8" x2="24" y2="20.8" stroke="black" stroke-width="2"/>
+</svg>

--- a/src/client/common/header/index.module.css
+++ b/src/client/common/header/index.module.css
@@ -1,0 +1,14 @@
+.header {
+    display: flex;
+    align-items: center;
+    height: 60px;
+    border-bottom: 1px solid rgb(0, 0, 0);
+}
+
+.title {
+    padding-left: 10px;
+}
+
+.navigationButton {
+    cursor: pointer;
+}

--- a/src/client/common/header/index.tsx
+++ b/src/client/common/header/index.tsx
@@ -1,0 +1,17 @@
+import { FunctionComponent } from 'react';
+import Image from 'next/image';
+import styles from './index.module.css';
+import { Navigation, useNavigation } from '../navigation';
+
+export const Header: FunctionComponent = () => {
+    const { navigationStatus, openNavigation, closeNavigation } = useNavigation();
+    return (
+        <div className={styles.header}>
+            <div className={styles.navigationButton} onClick={openNavigation}>
+                <Image src="navigation-button.svg" alt="navigation button" width={24} height={24} />
+            </div>
+            <h1 className={styles.title}>コロナ情報</h1>
+            {navigationStatus ? <Navigation closeNavigation={closeNavigation} /> : null}
+        </div>
+    );
+};

--- a/src/client/common/navigation/index.module.css
+++ b/src/client/common/navigation/index.module.css
@@ -1,0 +1,63 @@
+.container {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
+    z-index: 10;
+    max-width: 480px;
+    margin: auto;
+}
+
+.outer {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    overflow: hidden;
+    width: calc(100% - 300px);
+    background-color: rgba(0, 0, 0, 0.8);
+}
+
+.inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    overflow: hidden;
+    width: 300px;
+    background-color: #ffffff;
+}
+
+.header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    height: 60px;
+    padding-right: 8px;
+    border-bottom: 1px solid #757575;
+}
+
+.closeButton {
+    cursor: pointer;
+}
+
+.list {
+    padding: 0 10px;
+}
+
+.item {
+    display: flex;
+    align-items: center;
+    height: 40px;
+}
+
+.item:not(:last-child) {
+    border-bottom: 1px dashed #757575;
+}
+
+.link {
+    text-decoration: none;
+    color: #000000;
+}

--- a/src/client/common/navigation/index.tsx
+++ b/src/client/common/navigation/index.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { FunctionComponent, useCallback, useState } from 'react';
+import styles from './index.module.css';
+
+const ITEM_LIST = [
+    {
+        id: '01',
+        href: '/',
+        label: 'トップ',
+    },
+    {
+        id: '02',
+        href: '/count',
+        label: '各国別感染者数・死亡者数',
+    },
+    {
+        id: '03',
+        href: '/dummy',
+        label: 'ダミー3',
+    },
+    {
+        id: '04',
+        href: '/dummy',
+        label: 'ダミー4',
+    },
+];
+
+interface Props {
+    closeNavigation: UseNavigation['closeNavigation'];
+}
+
+export const Navigation: FunctionComponent<Props> = (props) => {
+    return (
+        <div className={styles.container}>
+            <div className={styles.outer} onClick={props.closeNavigation}></div>
+            <div className={styles.inner}>
+                <div className={styles.header}>
+                    <span className={styles.closeButton} onClick={props.closeNavigation}>
+                        close
+                    </span>
+                </div>
+                <ul className={styles.list}>
+                    {ITEM_LIST.map((item) => (
+                        <li className={styles.item} onClick={props.closeNavigation} key={item.id}>
+                            <Link className={styles.link} href={item.href}>
+                                {item.label}
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};
+
+interface UseNavigation {
+    navigationStatus: boolean;
+    openNavigation: () => void;
+    closeNavigation: () => void;
+}
+
+export const useNavigation = (): UseNavigation => {
+    const [navigationStatus, setNavigationStatus] = useState(false);
+    const openNavigation = useCallback(() => {
+        setNavigationStatus(true);
+    }, []);
+    const closeNavigation = useCallback(() => setNavigationStatus(false), []);
+
+    return {
+        navigationStatus,
+        openNavigation,
+        closeNavigation,
+    };
+};

--- a/src/client/corona/index.module.css
+++ b/src/client/corona/index.module.css
@@ -8,11 +8,6 @@
     width: 480px;
 }
 
-.header {
-    height: 60px;
-    border-bottom: 1px solid rgb(0, 0, 0);
-}
-
 .headerImage {
     padding-top: 10px;
 }

--- a/src/client/corona/index.tsx
+++ b/src/client/corona/index.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from 'react';
 import { CoronaInfo, CoronaInfoProps } from '../info';
 import { CoronaList, CoronaListProps } from '../list';
 import { CoronaChart, CoronaChartProps } from '../chart';
+import { Header } from '../common/header';
 
 interface Props {
     noticeInfo: CoronaInfoProps;
@@ -13,9 +14,7 @@ interface Props {
 export const Corona: FunctionComponent<Props> = (props) => (
     <div className={styles.main}>
         <div className={styles.container}>
-            <div className={styles.header}>
-                <h1>コロナ情報</h1>
-            </div>
+            <Header />
             <div className={styles.headerImage}>
                 <img src="https://article-image-ix.nikkei.com/https%3A%2F%2Fimgix-proxy.n8s.jp%2FDSXZQO1924133013052022000000-1.jpg?ixlib=js-2.3.2&w=638&h=395&auto=format%2Ccompress&ch=Width%2CDPR&q=45&fit=crop&bg=FFFFFF&s=1c759c0711a920c00dae258b17ade831" />
             </div>

--- a/src/client/info/index.tsx
+++ b/src/client/info/index.tsx
@@ -22,7 +22,8 @@ export const CoronaInfo: FunctionComponent<CoronaInfoProps> = (props) => {
             ) : null}
             {props.totalInfectedTokyo ? (
                 <li>
-                    東京は前日({props.infoFormatDate})より、{priceFormat(props.totalInfectedTokyo, 3)}
+                    東京は前日({props.infoFormatDate})より、
+                    {priceFormat(props.totalInfectedTokyo, 3)}
                     人増えています。
                 </li>
             ) : null}


### PR DESCRIPTION
## 概要(overview)
ナビゲーションコンポーネントを追加する

## チケット(ticket)

ticket | url
-- | --
ナビゲーションを作成 | https://github.com/will-of-work-80/corona-info/issues/2

## 詳細(detail)
- ページ遷移機能実装のため、ナビゲーションを実装する

## テスト(test)

![image](https://github.com/will-of-work-80/corona-info/assets/123068048/da12ef6f-f2ed-461c-9206-de0ca79fe0ef)

<img src="https://github.com/will-of-work-80/corona-info/assets/123068048/cfeccd8c-dd3a-444e-8e27-612d83c26ad9" width="300px" />




